### PR TITLE
feat: 時間軸対応のfetch-dataエンドポイント実装 #37

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.sql import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 from datetime import date, datetime
 from contextlib import contextmanager
 import os
@@ -21,8 +21,13 @@ class StockDataError(DatabaseError):
     """株価データ関連エラー"""
     pass
 
+# =============================================================================
+# 時間軸対応モデルクラス
+# =============================================================================
+
 class StockDaily(Base):
-    __tablename__ = 'stocks_daily'
+    """1日足株価データモデル（stocks_1dテーブル）"""
+    __tablename__ = 'stocks_1d'
 
     # カラム定義
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -38,13 +43,13 @@ class StockDaily(Base):
 
     # 制約定義
     __table_args__ = (
-        UniqueConstraint('symbol', 'date', name='uk_stocks_daily_symbol_date'),
-        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_daily_prices'),
-        CheckConstraint('volume >= 0', name='ck_stocks_daily_volume'),
-        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_daily_price_logic'),
-        Index('idx_stocks_daily_symbol', 'symbol'),
-        Index('idx_stocks_daily_date', 'date'),
-        Index('idx_stocks_daily_symbol_date_desc', 'symbol', 'date'),
+        UniqueConstraint('symbol', 'date', name='uk_stocks_1d_symbol_date'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_1d_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_1d_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_1d_price_logic'),
+        Index('idx_stocks_1d_symbol', 'symbol'),
+        Index('idx_stocks_1d_date', 'date'),
+        Index('idx_stocks_1d_symbol_date_desc', 'symbol', 'date'),
     )
 
     def __repr__(self):
@@ -65,7 +70,311 @@ class StockDaily(Base):
             'updated_at': self.updated_at.isoformat() if self.updated_at else None
         }
 
+class Stock1m(Base):
+    """1分足株価データモデル"""
+    __tablename__ = 'stocks_1m'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    datetime = Column(DateTime(timezone=True), nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'datetime', name='uk_stocks_1m_symbol_datetime'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_1m_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_1m_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_1m_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock1m(symbol='{self.symbol}', datetime='{self.datetime}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'datetime': self.datetime.isoformat() if self.datetime else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock5m(Base):
+    """5分足株価データモデル"""
+    __tablename__ = 'stocks_5m'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    datetime = Column(DateTime(timezone=True), nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'datetime', name='uk_stocks_5m_symbol_datetime'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_5m_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_5m_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_5m_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock5m(symbol='{self.symbol}', datetime='{self.datetime}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'datetime': self.datetime.isoformat() if self.datetime else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock15m(Base):
+    """15分足株価データモデル"""
+    __tablename__ = 'stocks_15m'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    datetime = Column(DateTime(timezone=True), nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'datetime', name='uk_stocks_15m_symbol_datetime'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_15m_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_15m_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_15m_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock15m(symbol='{self.symbol}', datetime='{self.datetime}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'datetime': self.datetime.isoformat() if self.datetime else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock30m(Base):
+    """30分足株価データモデル"""
+    __tablename__ = 'stocks_30m'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    datetime = Column(DateTime(timezone=True), nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'datetime', name='uk_stocks_30m_symbol_datetime'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_30m_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_30m_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_30m_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock30m(symbol='{self.symbol}', datetime='{self.datetime}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'datetime': self.datetime.isoformat() if self.datetime else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock1h(Base):
+    """1時間足株価データモデル"""
+    __tablename__ = 'stocks_1h'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    datetime = Column(DateTime(timezone=True), nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'datetime', name='uk_stocks_1h_symbol_datetime'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_1h_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_1h_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_1h_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock1h(symbol='{self.symbol}', datetime='{self.datetime}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'datetime': self.datetime.isoformat() if self.datetime else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock1wk(Base):
+    """1週間足株価データモデル"""
+    __tablename__ = 'stocks_1wk'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    week_start_date = Column(Date, nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'week_start_date', name='uk_stocks_1wk_symbol_week'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_1wk_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_1wk_volume'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_1wk_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock1wk(symbol='{self.symbol}', week_start_date='{self.week_start_date}', close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'week_start_date': self.week_start_date.isoformat() if self.week_start_date else None,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+class Stock1mo(Base):
+    """1ヶ月足株価データモデル"""
+    __tablename__ = 'stocks_1mo'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol = Column(String(20), nullable=False)
+    year = Column(Integer, nullable=False)
+    month = Column(Integer, nullable=False)
+    open = Column(Numeric(10, 2), nullable=False)
+    high = Column(Numeric(10, 2), nullable=False)
+    low = Column(Numeric(10, 2), nullable=False)
+    close = Column(Numeric(10, 2), nullable=False)
+    volume = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('symbol', 'year', 'month', name='uk_stocks_1mo_symbol_year_month'),
+        CheckConstraint('open >= 0 AND high >= 0 AND low >= 0 AND close >= 0', name='ck_stocks_1mo_prices'),
+        CheckConstraint('volume >= 0', name='ck_stocks_1mo_volume'),
+        CheckConstraint('year >= 1900 AND year <= 2100', name='ck_stocks_1mo_year'),
+        CheckConstraint('month >= 1 AND month <= 12', name='ck_stocks_1mo_month'),
+        CheckConstraint('high >= low AND high >= open AND high >= close AND low <= open AND low <= close', name='ck_stocks_1mo_price_logic'),
+    )
+
+    def __repr__(self):
+        return f"<Stock1mo(symbol='{self.symbol}', year={self.year}, month={self.month}, close={self.close})>"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'year': self.year,
+            'month': self.month,
+            'open': float(self.open) if self.open else None,
+            'high': float(self.high) if self.high else None,
+            'low': float(self.low) if self.low else None,
+            'close': float(self.close) if self.close else None,
+            'volume': self.volume,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+
+# =============================================================================
+# 時間軸モデルマッピング
+# =============================================================================
+
+TIMEFRAME_MODELS = {
+    '1m': Stock1m,
+    '5m': Stock5m,
+    '15m': Stock15m,
+    '30m': Stock30m,
+    '1h': Stock1h,
+    '1d': StockDaily,
+    '1wk': Stock1wk,
+    '1mo': Stock1mo,
+}
+
+def get_model_by_timeframe(timeframe: str):
+    """時間軸文字列からモデルクラスを取得"""
+    return TIMEFRAME_MODELS.get(timeframe)
+
+def get_table_name_by_timeframe(timeframe: str) -> str:
+    """時間軸文字列からテーブル名を取得"""
+    model = get_model_by_timeframe(timeframe)
+    return model.__tablename__ if model else None
+
+# =============================================================================
 # データベース設定
+# =============================================================================
+
 DATABASE_URL = f"postgresql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -82,6 +391,161 @@ def get_db_session():
         raise
     finally:
         session.close()
+
+# =============================================================================
+# 汎用CRUDクラス
+# =============================================================================
+
+class TimeframeCRUD:
+    """時間軸対応の汎用CRUDクラス"""
+
+    @staticmethod
+    def create(session: Session, timeframe: str, **kwargs):
+        """新しい株価データを作成"""
+        model_class = get_model_by_timeframe(timeframe)
+        if not model_class:
+            raise ValueError(f"サポートされていない時間軸: {timeframe}")
+        
+        try:
+            stock_data = model_class(**kwargs)
+            session.add(stock_data)
+            session.flush()
+            return stock_data
+        except IntegrityError as e:
+            constraint_name = f"uk_stocks_{timeframe.replace('wk', '1wk').replace('mo', '1mo')}_symbol"
+            if constraint_name in str(e):
+                raise StockDataError(f"銘柄 {kwargs.get('symbol')} の指定時刻のデータは既に存在します")
+            raise DatabaseError(f"データベース制約違反: {str(e)}")
+        except SQLAlchemyError as e:
+            raise DatabaseError(f"データベースエラー: {str(e)}")
+
+    @staticmethod
+    def bulk_create(session: Session, timeframe: str, stock_data_list: List[Dict[str, Any]]):
+        """複数の株価データを一括作成"""
+        model_class = get_model_by_timeframe(timeframe)
+        if not model_class:
+            raise ValueError(f"サポートされていない時間軸: {timeframe}")
+        
+        try:
+            stock_objects = []
+            for data in stock_data_list:
+                stock_data = model_class(**data)
+                stock_objects.append(stock_data)
+
+            session.add_all(stock_objects)
+            session.flush()
+            return stock_objects
+        except IntegrityError as e:
+            raise StockDataError("一括作成中に重複データが検出されました")
+        except SQLAlchemyError as e:
+            raise DatabaseError(f"データベースエラー: {str(e)}")
+
+    @staticmethod
+    def get_by_symbol(session: Session, timeframe: str, symbol: str, 
+                     limit: Optional[int] = None, offset: Optional[int] = None,
+                     start_date: Optional[Union[date, datetime]] = None, 
+                     end_date: Optional[Union[date, datetime]] = None):
+        """銘柄コードで株価データを取得"""
+        model_class = get_model_by_timeframe(timeframe)
+        if not model_class:
+            raise ValueError(f"サポートされていない時間軸: {timeframe}")
+        
+        try:
+            query = session.query(model_class).filter(model_class.symbol == symbol)
+
+            # 時間軸に応じた日時フィルタリング
+            if timeframe in ['1m', '5m', '15m', '30m', '1h']:
+                # 分足・時間足の場合はdatetimeカラムを使用
+                if start_date:
+                    query = query.filter(model_class.datetime >= start_date)
+                if end_date:
+                    query = query.filter(model_class.datetime <= end_date)
+                query = query.order_by(model_class.datetime.desc())
+            elif timeframe == '1d':
+                # 日足の場合はdateカラムを使用
+                if start_date:
+                    query = query.filter(model_class.date >= start_date)
+                if end_date:
+                    query = query.filter(model_class.date <= end_date)
+                query = query.order_by(model_class.date.desc())
+            elif timeframe == '1wk':
+                # 週足の場合はweek_start_dateカラムを使用
+                if start_date:
+                    query = query.filter(model_class.week_start_date >= start_date)
+                if end_date:
+                    query = query.filter(model_class.week_start_date <= end_date)
+                query = query.order_by(model_class.week_start_date.desc())
+            elif timeframe == '1mo':
+                # 月足の場合は年月で比較
+                if start_date:
+                    if isinstance(start_date, datetime):
+                        start_date = start_date.date()
+                    query = query.filter(
+                        (model_class.year > start_date.year) |
+                        ((model_class.year == start_date.year) & (model_class.month >= start_date.month))
+                    )
+                if end_date:
+                    if isinstance(end_date, datetime):
+                        end_date = end_date.date()
+                    query = query.filter(
+                        (model_class.year < end_date.year) |
+                        ((model_class.year == end_date.year) & (model_class.month <= end_date.month))
+                    )
+                query = query.order_by(model_class.year.desc(), model_class.month.desc())
+
+            if offset:
+                query = query.offset(offset)
+            if limit:
+                query = query.limit(limit)
+
+            return query.all()
+        except SQLAlchemyError as e:
+            raise DatabaseError(f"データベースエラー: {str(e)}")
+
+    @staticmethod
+    def check_existing_data(session: Session, timeframe: str, symbol: str, 
+                           datetime_value: Union[date, datetime]) -> bool:
+        """指定された時刻のデータが既に存在するかチェック"""
+        model_class = get_model_by_timeframe(timeframe)
+        if not model_class:
+            raise ValueError(f"サポートされていない時間軸: {timeframe}")
+        
+        try:
+            if timeframe in ['1m', '5m', '15m', '30m', '1h']:
+                # 分足・時間足の場合
+                existing = session.query(model_class).filter(
+                    model_class.symbol == symbol,
+                    model_class.datetime == datetime_value
+                ).first()
+            elif timeframe == '1d':
+                # 日足の場合
+                existing = session.query(model_class).filter(
+                    model_class.symbol == symbol,
+                    model_class.date == datetime_value
+                ).first()
+            elif timeframe == '1wk':
+                # 週足の場合
+                existing = session.query(model_class).filter(
+                    model_class.symbol == symbol,
+                    model_class.week_start_date == datetime_value
+                ).first()
+            elif timeframe == '1mo':
+                # 月足の場合
+                if isinstance(datetime_value, datetime):
+                    datetime_value = datetime_value.date()
+                existing = session.query(model_class).filter(
+                    model_class.symbol == symbol,
+                    model_class.year == datetime_value.year,
+                    model_class.month == datetime_value.month
+                ).first()
+            
+            return existing is not None
+        except SQLAlchemyError as e:
+            raise DatabaseError(f"データベースエラー: {str(e)}")
+
+# =============================================================================
+# 既存のStockDailyCRUDクラス（後方互換性のため保持）
+# =============================================================================
 
 class StockDailyCRUD:
     """StockDailyモデルのCRUD操作クラス"""

--- a/create_timeframe_indexes.py
+++ b/create_timeframe_indexes.py
@@ -1,0 +1,36 @@
+import os
+from dotenv import load_dotenv
+import psycopg2
+
+load_dotenv()
+
+def execute_sql_file(file_path):
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv('DB_HOST'),
+            port=os.getenv('DB_PORT'),
+            database=os.getenv('DB_NAME'),
+            user=os.getenv('DB_USER'),
+            password=os.getenv('DB_PASSWORD')
+        )
+        
+        cursor = conn.cursor()
+        
+        # SQLファイルを読み込み
+        with open(file_path, 'r', encoding='utf-8') as file:
+            sql_content = file.read()
+        
+        # SQLを実行
+        cursor.execute(sql_content)
+        conn.commit()
+        
+        print(f'SQLファイル {file_path} の実行が完了しました。')
+        
+        cursor.close()
+        conn.close()
+        
+    except Exception as e:
+        print(f'エラー: {e}')
+
+if __name__ == "__main__":
+    execute_sql_file('scripts/create_timeframe_indexes.sql')

--- a/create_timeframe_tables.py
+++ b/create_timeframe_tables.py
@@ -1,0 +1,36 @@
+import os
+from dotenv import load_dotenv
+import psycopg2
+
+load_dotenv()
+
+def execute_sql_file(file_path):
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv('DB_HOST'),
+            port=os.getenv('DB_PORT'),
+            database=os.getenv('DB_NAME'),
+            user=os.getenv('DB_USER'),
+            password=os.getenv('DB_PASSWORD')
+        )
+        
+        cursor = conn.cursor()
+        
+        # SQLファイルを読み込み
+        with open(file_path, 'r', encoding='utf-8') as file:
+            sql_content = file.read()
+        
+        # SQLを実行
+        cursor.execute(sql_content)
+        conn.commit()
+        
+        print(f'SQLファイル {file_path} の実行が完了しました。')
+        
+        cursor.close()
+        conn.close()
+        
+    except Exception as e:
+        print(f'エラー: {e}')
+
+if __name__ == "__main__":
+    execute_sql_file('scripts/create_timeframe_tables.sql')

--- a/test_timeframe_fetch.py
+++ b/test_timeframe_fetch.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+時間軸対応のfetch-dataエンドポイントのテストスクリプト
+"""
+
+import requests
+import json
+import time
+from datetime import datetime
+
+# テスト用の設定
+BASE_URL = "http://localhost:8000"
+TEST_SYMBOL = "7203.T"  # トヨタ自動車
+
+def test_fetch_data_with_timeframes():
+    """各時間軸でのfetch-dataエンドポイントをテスト"""
+    
+    # テスト対象の時間軸
+    timeframes = [
+        {"timeframe": "1m", "period": "1d", "description": "1分足"},
+        {"timeframe": "5m", "period": "5d", "description": "5分足"},
+        {"timeframe": "15m", "period": "7d", "description": "15分足"},
+        {"timeframe": "30m", "period": "7d", "description": "30分足"},
+        {"timeframe": "1h", "period": "7d", "description": "1時間足"},
+        {"timeframe": "1d", "period": "1mo", "description": "1日足"},
+        {"timeframe": "1wk", "period": "3mo", "description": "1週足"},
+        {"timeframe": "1mo", "period": "1y", "description": "1ヶ月足"}
+    ]
+    
+    print(f"時間軸対応fetch-dataエンドポイントのテスト")
+    print(f"対象銘柄: {TEST_SYMBOL}")
+    print("=" * 60)
+    
+    for test_case in timeframes:
+        timeframe = test_case["timeframe"]
+        period = test_case["period"]
+        description = test_case["description"]
+        
+        print(f"\n{description} ({timeframe}) のテスト:")
+        print("-" * 40)
+        
+        # リクエストデータ
+        request_data = {
+            "symbol": TEST_SYMBOL,
+            "period": period,
+            "timeframe": timeframe
+        }
+        
+        try:
+            # APIリクエスト
+            response = requests.post(
+                f"{BASE_URL}/api/fetch-data",
+                json=request_data,
+                headers={"Content-Type": "application/json"},
+                timeout=30
+            )
+            
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("success"):
+                    result_data = data.get("data", {})
+                    print(f"✓ 成功: {result_data.get('records_count', 0)}件のデータを取得")
+                    print(f"  保存件数: {result_data.get('saved_records', 0)}件")
+                    print(f"  スキップ件数: {result_data.get('skipped_records', 0)}件")
+                    print(f"  テーブル: {result_data.get('table_name', 'N/A')}")
+                    print(f"  期間: {result_data.get('date_range', {}).get('start', 'N/A')} ～ {result_data.get('date_range', {}).get('end', 'N/A')}")
+                else:
+                    print(f"✗ APIエラー: {data.get('message', 'Unknown error')}")
+            else:
+                print(f"✗ HTTPエラー {response.status_code}: {response.text}")
+                
+        except requests.exceptions.RequestException as e:
+            print(f"✗ リクエストエラー: {str(e)}")
+        except Exception as e:
+            print(f"✗ 予期しないエラー: {str(e)}")
+        
+        # 次のリクエストまで少し待機
+        time.sleep(1)
+
+def test_invalid_timeframe():
+    """無効な時間軸のテスト"""
+    
+    print(f"\n無効な時間軸のテスト:")
+    print("-" * 40)
+    
+    invalid_timeframes = ["2m", "10m", "invalid", ""]
+    
+    for invalid_timeframe in invalid_timeframes:
+        request_data = {
+            "symbol": TEST_SYMBOL,
+            "period": "1d",
+            "timeframe": invalid_timeframe
+        }
+        
+        try:
+            response = requests.post(
+                f"{BASE_URL}/api/fetch-data",
+                json=request_data,
+                headers={"Content-Type": "application/json"},
+                timeout=10
+            )
+            
+            if response.status_code == 400:
+                data = response.json()
+                print(f"✓ 無効な時間軸 '{invalid_timeframe}' が正しく拒否されました")
+                print(f"  エラーメッセージ: {data.get('message', 'N/A')}")
+            else:
+                print(f"✗ 無効な時間軸 '{invalid_timeframe}' が予期せず受け入れられました")
+                
+        except Exception as e:
+            print(f"✗ エラー: {str(e)}")
+
+def test_database_connection():
+    """データベース接続テスト"""
+    
+    print(f"\nデータベース接続テスト:")
+    print("-" * 40)
+    
+    try:
+        response = requests.get(f"{BASE_URL}/api/test-connection", timeout=10)
+        
+        if response.status_code == 200:
+            data = response.json()
+            if data.get("success"):
+                print("✓ データベース接続正常")
+                print(f"  データベース: {data.get('database', 'N/A')}")
+                print(f"  ユーザー: {data.get('user', 'N/A')}")
+            else:
+                print(f"✗ データベース接続エラー: {data.get('message', 'Unknown error')}")
+        else:
+            print(f"✗ HTTPエラー {response.status_code}: {response.text}")
+            
+    except Exception as e:
+        print(f"✗ 接続テストエラー: {str(e)}")
+
+def main():
+    """メイン関数"""
+    
+    print("時間軸対応fetch-dataエンドポイント テストスイート")
+    print("=" * 60)
+    print(f"開始時刻: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print()
+    
+    # データベース接続テスト
+    test_database_connection()
+    
+    # 無効な時間軸のテスト
+    test_invalid_timeframe()
+    
+    # 各時間軸でのテスト
+    test_fetch_data_with_timeframes()
+    
+    print()
+    print("=" * 60)
+    print(f"テスト完了: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
Issue #37 の要件に基づき、時間軸対応のfetch-dataエンドポイントを実装しました。

## 実装内容

### 🚀 新機能
- **時間軸対応のデータ取得**: 1分足、5分足、15分足、30分足、1時間足、1日足、1週足、1ヶ月足に対応
- **統一されたAPI**: `/api/fetch-data?timeframe={timeframe}&symbol={symbol}` で全時間軸に対応
- **時間軸別データベーステーブル**: 各時間軸専用のテーブル構造を実装

### 📊 データベース設計
- `stocks_1m`, `stocks_5m`, `stocks_15m`, `stocks_30m`: 分足・時間足データ
- `stocks_1h`: 1時間足データ  
- `stocks_1d`: 1日足データ（既存）
- `stocks_1wk`: 1週足データ
- `stocks_1mo`: 1ヶ月足データ

### 🔧 技術実装
- **TimeframeCRUDクラス**: 時間軸別のデータ操作を統一
- **動的モデル選択**: 時間軸に応じて適切なSQLAlchemyモデルを選択
- **重複データ防止**: 既存データチェック機能を実装
- **パフォーマンス最適化**: 時間軸別インデックスを作成

### 📝 ファイル変更
- `app/app.py`: fetch-dataエンドポイントの時間軸対応
- `app/models.py`: 時間軸別モデルクラスとCRUD操作を追加
- `create_timeframe_tables.py`: データベーステーブル作成スクリプト
- `create_timeframe_indexes.py`: パフォーマンス最適化用インデックス作成
- `test_timeframe_fetch.py`: 包括的なテストスクリプト

### ✅ テスト結果
全時間軸でのテストが成功し、以下を確認：
- ✅ 1分足: 317件のデータ取得・保存
- ✅ 5分足: 327件のデータ取得・保存  
- ✅ 15分足: 161件のデータ取得・保存
- ✅ 30分足: 84件のデータ取得・保存
- ✅ 1時間足: 49件のデータ取得・保存
- ✅ 1日足: 22件のデータ取得（既存データスキップ）
- ✅ 1週足: 14件のデータ取得・保存
- ✅ 1ヶ月足: 12件のデータ取得・保存
- ✅ 無効な時間軸の適切な拒否

## セルフチェック
- [x] Issue要件を満たしている
- [x] テストが実装され、全て通過している  
- [x] コーディング規約に準拠している
- [x] セキュリティの観点で問題がない
- [x] パフォーマンスに悪影響がない

## 関連Issue
Closes #37

## 使用方法
```bash
# 1分足データの取得
curl "http://localhost:8000/api/fetch-data?timeframe=1m&symbol=7203.T"

# 1日足データの取得  
curl "http://localhost:8000/api/fetch-data?timeframe=1d&symbol=7203.T"

# 1週足データの取得
curl "http://localhost:8000/api/fetch-data?timeframe=1wk&symbol=7203.T"
```