### PR TITLE
#84: バッチ処理監視・ログ機能実装（Phase 2）

### DIFF
--- a/app/utils/structured_logger.py
+++ b/app/utils/structured_logger.py
@@ -1,0 +1,197 @@
+"""構造化ログ出力モジュール
+
+Phase 2要件: バッチ処理の詳細なログ出力とメトリクス収集機能
+仕様書: docs/api_bulk_fetch.md (772-787行目)
+"""
+
+import json
+import logging
+import logging.handlers
+from datetime import datetime
+from typing import Any, Dict, Optional
+from pathlib import Path
+
+
+class StructuredFormatter(logging.Formatter):
+    """JSON形式の構造化ログフォーマッター"""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """ログレコードをJSON形式にフォーマット"""
+        log_data = {
+            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # 追加のフィールドがあれば含める
+        if hasattr(record, 'batch_id'):
+            log_data['batch_id'] = record.batch_id
+        if hasattr(record, 'worker_id'):
+            log_data['worker_id'] = record.worker_id
+        if hasattr(record, 'stock_code'):
+            log_data['stock_code'] = record.stock_code
+        if hasattr(record, 'action'):
+            log_data['action'] = record.action
+        if hasattr(record, 'status'):
+            log_data['status'] = record.status
+        if hasattr(record, 'duration_ms'):
+            log_data['duration_ms'] = record.duration_ms
+        if hasattr(record, 'records_count'):
+            log_data['records_count'] = record.records_count
+        if hasattr(record, 'error_message'):
+            log_data['error_message'] = record.error_message
+        if hasattr(record, 'retry_count'):
+            log_data['retry_count'] = record.retry_count
+
+        return json.dumps(log_data, ensure_ascii=False)
+
+
+class BatchLoggerAdapter(logging.LoggerAdapter):
+    """バッチ処理用ログアダプター
+
+    構造化ログ出力用の追加情報を管理します。
+    """
+
+    def process(self, msg: str, kwargs: Dict[str, Any]) -> tuple:
+        """ログメッセージに追加情報を付与"""
+        extra = kwargs.get('extra', {})
+
+        # コンテキスト情報をマージ
+        if self.extra:
+            extra.update(self.extra)
+
+        kwargs['extra'] = extra
+        return msg, kwargs
+
+    def log_batch_action(
+        self,
+        action: str,
+        stock_code: Optional[str] = None,
+        status: str = 'success',
+        duration_ms: Optional[int] = None,
+        records_count: Optional[int] = None,
+        error_message: Optional[str] = None,
+        retry_count: int = 0,
+        **kwargs
+    ):
+        """バッチ処理のアクションをログ出力
+
+        Args:
+            action: アクション種別 (data_fetch, data_save, error_occurred等)
+            stock_code: 銘柄コード
+            status: ステータス (success, failed, retry)
+            duration_ms: 処理時間（ミリ秒）
+            records_count: レコード数
+            error_message: エラーメッセージ
+            retry_count: リトライ回数
+            **kwargs: 追加のログ情報
+        """
+        extra = {
+            'action': action,
+            'status': status,
+            'retry_count': retry_count
+        }
+
+        if stock_code:
+            extra['stock_code'] = stock_code
+        if duration_ms is not None:
+            extra['duration_ms'] = duration_ms
+        if records_count is not None:
+            extra['records_count'] = records_count
+        if error_message:
+            extra['error_message'] = error_message
+
+        # 追加のフィールドを含める
+        extra.update(kwargs)
+
+        # ステータスに応じたログレベルを選択
+        if status == 'failed':
+            self.error(f"[{action}] {stock_code or 'N/A'}: {error_message or 'Unknown error'}", extra=extra)
+        elif status == 'retry':
+            self.warning(f"[{action}] {stock_code or 'N/A'}: Retry {retry_count}", extra=extra)
+        else:
+            self.info(f"[{action}] {stock_code or 'N/A'}: Success", extra=extra)
+
+
+def setup_structured_logging(
+    log_dir: str = 'logs',
+    log_level: int = logging.INFO,
+    max_bytes: int = 10 * 1024 * 1024,  # 10MB
+    backup_count: int = 10,
+    enable_console: bool = True,
+    enable_file: bool = True
+) -> logging.Logger:
+    """構造化ログ設定
+
+    Args:
+        log_dir: ログディレクトリ
+        log_level: ログレベル
+        max_bytes: ログファイルの最大サイズ（バイト）
+        backup_count: バックアップファイル数
+        enable_console: コンソール出力を有効化
+        enable_file: ファイル出力を有効化
+
+    Returns:
+        設定済みのロガー
+    """
+    # ログディレクトリの作成
+    log_path = Path(log_dir)
+    log_path.mkdir(exist_ok=True)
+
+    # ルートロガーの取得
+    logger = logging.getLogger('bulk_batch')
+    logger.setLevel(log_level)
+    logger.handlers.clear()  # 既存のハンドラをクリア
+
+    formatter = StructuredFormatter()
+
+    # ファイルハンドラ（ローテーション付き）
+    if enable_file:
+        file_handler = logging.handlers.RotatingFileHandler(
+            filename=log_path / 'batch_bulk.log',
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding='utf-8'
+        )
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    # コンソールハンドラ
+    if enable_console:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(log_level)
+        # コンソールは人間が読みやすい形式
+        console_formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        console_handler.setFormatter(console_formatter)
+        logger.addHandler(console_handler)
+
+    return logger
+
+
+def get_batch_logger(
+    batch_id: Optional[str] = None,
+    worker_id: Optional[int] = None
+) -> BatchLoggerAdapter:
+    """バッチ処理用ロガーを取得
+
+    Args:
+        batch_id: バッチID
+        worker_id: ワーカーID
+
+    Returns:
+        バッチロガーアダプター
+    """
+    logger = logging.getLogger('bulk_batch')
+
+    extra = {}
+    if batch_id:
+        extra['batch_id'] = batch_id
+    if worker_id is not None:
+        extra['worker_id'] = worker_id
+
+    return BatchLoggerAdapter(logger, extra)

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,200 @@
+# バッチ処理監視・ログ機能ガイド
+
+## 概要
+
+Phase 2で実装されたバッチ処理の監視・ログ機能について説明します。
+
+## 構造化ログ
+
+### ログフォーマット
+
+バッチ処理のログはJSON形式で出力されます。
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "batch_id": "batch_20240115_103000",
+  "worker_id": 1,
+  "stock_code": "7203",
+  "action": "data_fetch",
+  "status": "success",
+  "duration_ms": 1500,
+  "records_count": 50,
+  "error_message": null,
+  "retry_count": 0
+}
+```
+
+### ログレベル
+
+- **INFO**: 正常な処理の記録
+- **WARNING**: リトライが発生した場合
+- **ERROR**: エラーが発生した場合
+
+### アクション種別
+
+- `data_fetch`: データ取得
+- `data_save`: データ保存
+- `error_occurred`: エラー発生
+
+### ステータス
+
+- `success`: 成功
+- `failed`: 失敗
+- `retry`: リトライ中
+
+## ログローテーション
+
+ログファイルは自動的にローテーションされます。
+
+### 設定
+
+- **最大ファイルサイズ**: 10MB
+- **バックアップファイル数**: 10個
+- **ログディレクトリ**: `logs/`
+- **ログファイル名**: `batch_bulk.log`
+
+### ローテーション動作
+
+1. `batch_bulk.log` が 10MB に達すると、`batch_bulk.log.1` にリネーム
+2. 古いログは `.2`, `.3` ... と順次リネーム
+3. 最大10個のバックアップファイルを保持
+4. 11個目以降は自動削除
+
+## メトリクス収集
+
+### 進捗情報
+
+バッチ処理の進捗情報には以下のメトリクスが含まれます:
+
+```python
+{
+    'total': 100,              # 総銘柄数
+    'processed': 50,           # 処理済み銘柄数
+    'successful': 45,          # 成功数
+    'failed': 5,               # 失敗数
+    'progress_percentage': 50.0,  # 進捗率
+    'elapsed_time': 120.5,     # 経過時間（秒）
+    'stocks_per_second': 0.41, # 処理速度（銘柄/秒）
+    'estimated_completion': '2024-01-15T14:30:00',  # ETA
+
+    # Phase 2メトリクス
+    'throughput': {
+        'stocks_per_minute': 24.6,    # 分あたり処理銘柄数
+        'records_per_minute': 1230.0  # 分あたり処理レコード数
+    },
+    'performance': {
+        'success_rate': 90.0,              # 成功率 (%)
+        'avg_processing_time_ms': 2400.0,  # 平均処理時間（ミリ秒）
+        'total_records_fetched': 2250,     # 総取得レコード数
+        'total_records_saved': 2150        # 総保存レコード数
+    }
+}
+```
+
+### パフォーマンス監視
+
+#### スループット
+
+- **stocks_per_minute**: 1分あたりに処理できる銘柄数
+- **records_per_minute**: 1分あたりに保存できるレコード数
+
+#### 成功率
+
+- **success_rate**: 処理成功率（%）
+- 計算式: `(成功数 / 処理済み数) × 100`
+
+#### 平均処理時間
+
+- **avg_processing_time_ms**: 銘柄あたりの平均処理時間（ミリ秒）
+- データ取得から保存までの時間を含む
+
+## 完了予定時刻（ETA）
+
+### 計算方法
+
+ETAは以下の方法で計算されます:
+
+1. **経過時間の計算**: 開始時刻から現在までの経過時間
+2. **処理速度の計算**: `処理済み数 / 経過時間`
+3. **残り時間の推定**: `残り数 / 処理速度`
+4. **ETAの算出**: `現在時刻 + 残り時間`
+
+### 精度向上のポイント
+
+- 処理が進むほど精度が向上します
+- 最初の数件ではETAが大きくぶれる可能性があります
+- 10件以上処理した後のETAが比較的正確です
+
+## 使用例
+
+### Pythonでの使用
+
+```python
+from services.bulk_data_service import BulkDataService
+from utils.structured_logger import setup_structured_logging
+
+# 構造化ログ設定
+setup_structured_logging(
+    log_dir='logs',
+    log_level=logging.INFO
+)
+
+# バッチサービス初期化（batch_idを指定）
+service = BulkDataService(
+    max_workers=10,
+    batch_id='batch-001'
+)
+
+# バッチ処理実行
+result = service.fetch_multiple_stocks(
+    symbols=['7203.T', '6758.T'],
+    interval='1d',
+    period='1mo'
+)
+
+# メトリクス確認
+print(f"成功率: {result['performance']['success_rate']}%")
+print(f"平均処理時間: {result['performance']['avg_processing_time_ms']}ms")
+print(f"スループット: {result['throughput']['stocks_per_minute']}銘柄/分")
+```
+
+### ログファイルの確認
+
+```bash
+# 最新ログの確認
+tail -f logs/batch_bulk.log
+
+# JSON形式で整形して表示
+tail -n 10 logs/batch_bulk.log | jq .
+
+# 特定の銘柄のログを抽出
+grep "7203" logs/batch_bulk.log | jq .
+
+# エラーのみ抽出
+grep '"status":"failed"' logs/batch_bulk.log | jq .
+```
+
+## トラブルシューティング
+
+### ログが出力されない
+
+1. `logs/` ディレクトリが存在するか確認
+2. 書き込み権限があるか確認
+3. `setup_structured_logging()` が呼ばれているか確認
+
+### メトリクスが正しく表示されない
+
+1. `tracker.update()` に必要なパラメータが渡されているか確認
+2. `duration_ms`, `records_fetched`, `records_saved` が正しく設定されているか確認
+
+### ETAが表示されない
+
+1. 処理が開始されているか確認
+2. `stocks_per_second` が0より大きいか確認（処理が進んでいない場合はETAは計算されません）
+
+## 参考
+
+- [仕様書](../docs/api_bulk_fetch.md) - Phase 2の詳細仕様
+- [テストコード](../tests/test_structured_logger.py) - 構造化ログのテスト
+- [メトリクステスト](../tests/test_progress_metrics.py) - メトリクス収集のテスト

--- a/tests/test_progress_metrics.py
+++ b/tests/test_progress_metrics.py
@@ -1,0 +1,196 @@
+"""進捗トラッカーとメトリクス収集のテスト
+
+Phase 2要件: メトリクス収集機能のテスト
+"""
+
+import pytest
+import time
+from services.bulk_data_service import ProgressTracker
+
+
+class TestProgressTracker:
+    """進捗トラッカーのテスト"""
+
+    def test_initialization(self):
+        """初期化のテスト"""
+        tracker = ProgressTracker(total=100)
+
+        assert tracker.total == 100
+        assert tracker.processed == 0
+        assert tracker.successful == 0
+        assert tracker.failed == 0
+        assert tracker.current_symbol is None
+        assert len(tracker.error_details) == 0
+
+    def test_update_success(self):
+        """成功時の更新テスト"""
+        tracker = ProgressTracker(total=10)
+
+        tracker.update(
+            symbol='7203.T',
+            success=True,
+            duration_ms=1500,
+            records_fetched=50,
+            records_saved=50
+        )
+
+        assert tracker.processed == 1
+        assert tracker.successful == 1
+        assert tracker.failed == 0
+        assert tracker.current_symbol == '7203.T'
+        assert len(tracker.processing_times) == 1
+        assert tracker.processing_times[0] == 1500
+        assert sum(tracker.records_fetched_list) == 50
+        assert sum(tracker.records_saved_list) == 50
+
+    def test_update_failed(self):
+        """失敗時の更新テスト"""
+        tracker = ProgressTracker(total=10)
+
+        tracker.update(
+            symbol='9999.T',
+            success=False,
+            error_message='Connection timeout'
+        )
+
+        assert tracker.processed == 1
+        assert tracker.successful == 0
+        assert tracker.failed == 1
+        assert tracker.current_symbol == '9999.T'
+        assert len(tracker.error_details) == 1
+        assert tracker.error_details[0]['symbol'] == '9999.T'
+        assert 'Connection timeout' in tracker.error_details[0]['error']
+
+    def test_get_progress(self):
+        """進捗情報取得のテスト"""
+        tracker = ProgressTracker(total=10)
+
+        # 複数の銘柄を処理
+        for i in range(5):
+            tracker.update(
+                symbol=f'stock{i}.T',
+                success=True,
+                duration_ms=1000,
+                records_fetched=50,
+                records_saved=45
+            )
+
+        time.sleep(0.1)  # わずかに時間経過
+
+        progress = tracker.get_progress()
+
+        assert progress['total'] == 10
+        assert progress['processed'] == 5
+        assert progress['successful'] == 5
+        assert progress['failed'] == 0
+        assert progress['progress_percentage'] == 50.0
+        assert progress['elapsed_time'] > 0
+        assert progress['stocks_per_second'] > 0
+        assert progress['estimated_completion'] is not None
+
+        # Phase 2メトリクス
+        assert 'throughput' in progress
+        assert progress['throughput']['stocks_per_minute'] > 0
+        assert progress['throughput']['records_per_minute'] > 0
+
+        assert 'performance' in progress
+        assert progress['performance']['success_rate'] == 100.0
+        assert progress['performance']['avg_processing_time_ms'] == 1000.0
+        assert progress['performance']['total_records_fetched'] == 250
+        assert progress['performance']['total_records_saved'] == 225
+
+    def test_metrics_calculation(self):
+        """メトリクス計算のテスト"""
+        tracker = ProgressTracker(total=20)
+
+        # 成功: 15件、失敗: 5件
+        for i in range(15):
+            tracker.update(
+                symbol=f'stock{i}.T',
+                success=True,
+                duration_ms=1000 + i * 100,  # 処理時間を変化させる
+                records_fetched=50,
+                records_saved=48
+            )
+
+        for i in range(5):
+            tracker.update(
+                symbol=f'fail{i}.T',
+                success=False,
+                error_message='Test error'
+            )
+
+        progress = tracker.get_progress()
+
+        # 成功率の確認
+        assert progress['performance']['success_rate'] == 75.0  # 15/20 = 75%
+
+        # 平均処理時間の確認
+        expected_avg = sum(1000 + i * 100 for i in range(15)) / 15
+        assert abs(progress['performance']['avg_processing_time_ms'] - expected_avg) < 0.1
+
+        # レコード数の確認
+        assert progress['performance']['total_records_fetched'] == 750  # 15 * 50
+        assert progress['performance']['total_records_saved'] == 720  # 15 * 48
+
+    def test_get_summary(self):
+        """サマリー取得のテスト"""
+        tracker = ProgressTracker(total=5)
+
+        for i in range(5):
+            tracker.update(
+                symbol=f'stock{i}.T',
+                success=True,
+                duration_ms=1000,
+                records_fetched=50,
+                records_saved=50
+            )
+
+        summary = tracker.get_summary()
+
+        assert summary['status'] == 'completed'
+        assert summary['total'] == 5
+        assert summary['processed'] == 5
+        assert summary['successful'] == 5
+        assert 'end_time' in summary
+        assert 'throughput' in summary
+        assert 'performance' in summary
+
+    def test_empty_metrics(self):
+        """空のメトリクスのテスト"""
+        tracker = ProgressTracker(total=10)
+
+        progress = tracker.get_progress()
+
+        # 処理が0件の場合でもエラーにならないこと
+        assert progress['throughput']['stocks_per_minute'] == 0
+        assert progress['performance']['success_rate'] == 0
+        assert progress['performance']['avg_processing_time_ms'] == 0
+        assert progress['performance']['total_records_fetched'] == 0
+        assert progress['performance']['total_records_saved'] == 0
+
+    def test_eta_calculation(self):
+        """ETA計算のテスト"""
+        tracker = ProgressTracker(total=10)
+
+        # 5件処理
+        for i in range(5):
+            tracker.update(
+                symbol=f'stock{i}.T',
+                success=True,
+                duration_ms=1000,
+                records_fetched=50,
+                records_saved=50
+            )
+
+        time.sleep(0.5)  # 0.5秒待機
+
+        progress = tracker.get_progress()
+
+        # ETAが計算されていることを確認
+        assert progress['estimated_completion'] is not None
+
+        # 残り5件なので、ETAは現在時刻より未来であること
+        from datetime import datetime
+        eta = datetime.fromisoformat(progress['estimated_completion'])
+        assert eta > datetime.now()

--- a/tests/test_structured_logger.py
+++ b/tests/test_structured_logger.py
@@ -1,0 +1,163 @@
+"""構造化ログのテスト
+
+Phase 2要件: 構造化ログ出力とメトリクス収集のテスト
+"""
+
+import json
+import logging
+import pytest
+from pathlib import Path
+from utils.structured_logger import (
+    StructuredFormatter,
+    BatchLoggerAdapter,
+    setup_structured_logging,
+    get_batch_logger
+)
+
+
+class TestStructuredFormatter:
+    """構造化ログフォーマッターのテスト"""
+
+    def test_basic_format(self):
+        """基本的なフォーマットのテスト"""
+        formatter = StructuredFormatter()
+        record = logging.LogRecord(
+            name='test',
+            level=logging.INFO,
+            pathname='test.py',
+            lineno=1,
+            msg='Test message',
+            args=(),
+            exc_info=None
+        )
+
+        result = formatter.format(record)
+        data = json.loads(result)
+
+        assert 'timestamp' in data
+        assert data['level'] == 'INFO'
+        assert data['logger'] == 'test'
+        assert data['message'] == 'Test message'
+
+    def test_batch_fields(self):
+        """バッチフィールドのテスト"""
+        formatter = StructuredFormatter()
+        record = logging.LogRecord(
+            name='test',
+            level=logging.INFO,
+            pathname='test.py',
+            lineno=1,
+            msg='Batch operation',
+            args=(),
+            exc_info=None
+        )
+        record.batch_id = 'batch-123'
+        record.worker_id = 1
+        record.stock_code = '7203.T'
+        record.action = 'data_fetch'
+        record.status = 'success'
+        record.duration_ms = 1500
+        record.records_count = 50
+
+        result = formatter.format(record)
+        data = json.loads(result)
+
+        assert data['batch_id'] == 'batch-123'
+        assert data['worker_id'] == 1
+        assert data['stock_code'] == '7203.T'
+        assert data['action'] == 'data_fetch'
+        assert data['status'] == 'success'
+        assert data['duration_ms'] == 1500
+        assert data['records_count'] == 50
+
+
+class TestBatchLoggerAdapter:
+    """バッチロガーアダプターのテスト"""
+
+    def test_log_batch_action_success(self, caplog):
+        """成功時のバッチアクションログのテスト"""
+        logger = logging.getLogger('test_batch')
+        logger.setLevel(logging.INFO)
+
+        adapter = BatchLoggerAdapter(logger, {'batch_id': 'test-batch'})
+
+        with caplog.at_level(logging.INFO):
+            adapter.log_batch_action(
+                action='data_fetch',
+                stock_code='7203.T',
+                status='success',
+                duration_ms=1000,
+                records_count=50
+            )
+
+        assert len(caplog.records) == 1
+        assert 'data_fetch' in caplog.text
+        assert '7203.T' in caplog.text
+
+    def test_log_batch_action_failed(self, caplog):
+        """失敗時のバッチアクションログのテスト"""
+        logger = logging.getLogger('test_batch_failed')
+        logger.setLevel(logging.ERROR)
+
+        adapter = BatchLoggerAdapter(logger, {'batch_id': 'test-batch'})
+
+        with caplog.at_level(logging.ERROR):
+            adapter.log_batch_action(
+                action='data_fetch',
+                stock_code='9999.T',
+                status='failed',
+                error_message='Connection timeout'
+            )
+
+        assert len(caplog.records) == 1
+        assert 'failed' in caplog.text or 'Connection timeout' in caplog.text
+
+    def test_log_batch_action_retry(self, caplog):
+        """リトライ時のバッチアクションログのテスト"""
+        logger = logging.getLogger('test_batch_retry')
+        logger.setLevel(logging.WARNING)
+
+        adapter = BatchLoggerAdapter(logger, {'batch_id': 'test-batch'})
+
+        with caplog.at_level(logging.WARNING):
+            adapter.log_batch_action(
+                action='data_fetch',
+                stock_code='7203.T',
+                status='retry',
+                retry_count=1
+            )
+
+        assert len(caplog.records) == 1
+        assert 'retry' in caplog.text.lower() or 'Retry' in caplog.text
+
+
+class TestLoggingSetup:
+    """ログ設定のテスト"""
+
+    def test_setup_logging(self, tmp_path):
+        """ログ設定のテスト"""
+        log_dir = tmp_path / 'logs'
+
+        logger = setup_structured_logging(
+            log_dir=str(log_dir),
+            log_level=logging.INFO,
+            enable_console=False,
+            enable_file=True
+        )
+
+        assert logger is not None
+        assert logger.level == logging.INFO
+        assert log_dir.exists()
+
+        # ログファイルが作成されることを確認
+        logger.info('Test log message')
+        log_file = log_dir / 'batch_bulk.log'
+        assert log_file.exists()
+
+    def test_get_batch_logger(self):
+        """バッチロガー取得のテスト"""
+        adapter = get_batch_logger(batch_id='test-123', worker_id=1)
+
+        assert isinstance(adapter, BatchLoggerAdapter)
+        assert adapter.extra['batch_id'] == 'test-123'
+        assert adapter.extra['worker_id'] == 1


### PR DESCRIPTION
## 概要
Issue #84に基づき、バッチ処理の監視・ログ機能（Phase 2）を実装しました。

## 実装内容

### 1. 構造化ログ出力 ✅
- JSON形式でのログ出力機能を実装
- ログレベル: INFO/WARNING/ERROR
- アクション種別: data_fetch/data_save/error_occurred
- バッチID、ワーカーID、銘柄コード等の詳細情報を含む
- 実装ファイル: [app/utils/structured_logger.py](../app/utils/structured_logger.py)

### 2. メトリクス収集機能 ✅
- **スループット**: 銘柄/分、レコード/分
- **成功率**: 処理成功率（%）
- **平均処理時間**: ミリ秒単位
- **総取得/保存レコード数**: リアルタイム集計
- 実装ファイル: [app/services/bulk_data_service.py](../app/services/bulk_data_service.py)

### 3. ログローテーション設定 ✅
- 最大ファイルサイズ: 10MB
- バックアップファイル数: 10個
- 自動ローテーション機能
- Python標準ライブラリの`RotatingFileHandler`を使用

### 4. パフォーマンス監視機能 ✅
- リアルタイムメトリクス収集
- 進捗情報にメトリクスを統合
- WebSocket経由での進捗配信にも対応

### 5. 完了予定時刻（ETA）算出機能 ✅
- 処理速度に基づくETA計算
- 精度向上アルゴリズム
- 既存の`ProgressTracker`を拡張

## テスト結果

### 構造化ログのテスト
```bash
tests/test_structured_logger.py
✅ TestStructuredFormatter::test_basic_format
✅ TestStructuredFormatter::test_batch_fields
✅ TestBatchLoggerAdapter::test_log_batch_action_success
✅ TestBatchLoggerAdapter::test_log_batch_action_failed
✅ TestBatchLoggerAdapter::test_log_batch_action_retry
✅ TestLoggingSetup::test_setup_logging
✅ TestLoggingSetup::test_get_batch_logger

✅ 7件すべて成功
```

### メトリクス収集のテスト
```bash
tests/test_progress_metrics.py
✅ TestProgressTracker::test_initialization
✅ TestProgressTracker::test_update_success
✅ TestProgressTracker::test_update_failed
✅ TestProgressTracker::test_get_progress
✅ TestProgressTracker::test_metrics_calculation
✅ TestProgressTracker::test_get_summary
✅ TestProgressTracker::test_empty_metrics
✅ TestProgressTracker::test_eta_calculation

✅ 8件すべて成功
```

### 全テストの結果
- **総テスト数**: 231件
- **成功**: 211件
- **スキップ**: 20件（Chromeブラウザが必要なE2Eテスト）
- **失敗**: 0件

## ドキュメント

新規作成したドキュメント:
- [docs/MONITORING.md](../docs/MONITORING.md) - 監視・ログ機能の詳細ガイド
  - ログフォーマットの説明
  - ログローテーションの設定
  - メトリクス収集の詳細
  - 使用例とトラブルシューティング

## PRレビュー重点観点

- [x] ログ出力が適切か → JSON形式で構造化されており、必要な情報を含む
- [x] メトリクス収集が効果的か → スループット、成功率、平均処理時間を正確に計算
- [x] ログフォーマットが統一されているか → `StructuredFormatter`により統一
- [x] パフォーマンス監視が適切か → リアルタイムメトリクス収集を実装
- [x] 実装内容が仕様書（api_bulk_fetch.md）と一致しているか → Phase 2要件に完全準拠

## 影響範囲

- **新規ファイル**:
  - `app/utils/structured_logger.py` (197行)
  - `docs/MONITORING.md` (200行)
  - `tests/test_structured_logger.py` (163行)
  - `tests/test_progress_metrics.py` (196行)

- **変更ファイル**:
  - `app/services/bulk_data_service.py` (+132/-10行)

## 参考仕様書
- [api_bulk_fetch.md](../docs/api_bulk_fetch.md) (Phase 2 - 監視・ログ)
  - 772-787行目: 構造化ログフォーマット
  - 790-796行目: メトリクス収集項目
  - 670-681行目: ETA算出機能

🤖 Generated with [Claude Code](https://claude.com/claude-code)