### PR TITLE
feat: フォーマッタ・Linterの導入と設定 (Issue #108)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,62 @@
+[flake8]
+# 最大行長（PEP 8準拠）
+max-line-length = 79
+
+# 複雑度の閾値（McCabe complexity）
+max-complexity = 10
+
+# 除外ディレクトリ
+exclude =
+    .git,
+    __pycache__,
+    .pytest_cache,
+    venv,
+    .venv,
+    migrations,
+    build,
+    dist,
+    *.egg-info,
+    .eggs,
+    .serena,
+    .claude
+
+# 無視するエラーコード
+ignore =
+    # E203: whitespace before ':' (Blackと競合)
+    E203,
+    # W503: line break before binary operator (PEP 8で推奨される改行位置)
+    W503,
+    # E501: line too long (Blackに任せる)
+    E501,
+
+# 1行あたりのインポート数
+max-line-complexity = 18
+
+# docstringのチェック
+docstring-convention = google
+
+# 型ヒントのチェックを有効化
+enable-extensions =
+    # G: flake8-logging-format
+    # B: flake8-bugbear
+    # C: mccabe
+
+# ファイルごとの無視設定
+per-file-ignores =
+    # __init__.pyではF401（未使用のインポート）を許可
+    __init__.py:F401,F403
+    # テストファイルではいくつかのルールを緩和
+    test_*.py:D100,D101,D102,D103,F401,F811
+    tests/*.py:D100,D101,D102,D103,F401,F811
+
+# カウント表示を有効化
+count = True
+
+# 統計情報を表示
+statistics = True
+
+# エラー表示形式
+format = default
+
+# 並列実行数（自動）
+jobs = auto

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,9 @@ dmypy.json
 .pyre/
 
 # IDEs
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.flake8",
+    "ms-python.pylint",
+    "ms-python.mypy-type-checker",
+    "ms-python.vscode-pylance"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,90 @@
+{
+  // ===== Python設定 =====
+  "python.defaultInterpreterPath": "${workspaceFolder}/venv/Scripts/python.exe",
+
+  // ===== フォーマッター設定 =====
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "editor.formatOnType": false,
+
+  // Pythonのフォーマッターとしてblackを使用
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    },
+    "editor.rulers": [79]
+  },
+
+  // ===== Black設定 =====
+  "black-formatter.args": [
+    "--line-length=79"
+  ],
+
+  // ===== isort設定 =====
+  "isort.args": [
+    "--profile=black",
+    "--line-length=79"
+  ],
+  "isort.check": true,
+
+  // ===== Linter設定 =====
+  // Flake8
+  "flake8.args": [
+    "--config=${workspaceFolder}/.flake8"
+  ],
+  "flake8.enabled": true,
+
+  // Pylint
+  "pylint.args": [
+    "--rcfile=${workspaceFolder}/pyproject.toml"
+  ],
+  "pylint.enabled": true,
+
+  // ===== 型チェック設定 =====
+  "python.analysis.typeCheckingMode": "basic",
+  "mypy-type-checker.args": [
+    "--config-file=${workspaceFolder}/pyproject.toml"
+  ],
+
+  // ===== Python全般設定 =====
+  "python.linting.enabled": true,
+  "python.linting.lintOnSave": true,
+
+  // テスト設定
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+
+  // ===== エディター設定 =====
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+
+  // 除外ファイル
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.pyc": true,
+    "**/.pytest_cache": true,
+    "**/.mypy_cache": true,
+    "**/.git": true
+  },
+
+  // ===== ファイル監視除外 =====
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/**": true,
+    "**/venv/**": true,
+    "**/.venv/**": true,
+    "**/__pycache__/**": true,
+    "**/.pytest_cache/**": true,
+    "**/.mypy_cache/**": true
+  },
+
+  // ===== 拡張機能の推奨 =====
+  "extensions.ignoreRecommendations": false
+}

--- a/docs/development/formatter_linter_guide.md
+++ b/docs/development/formatter_linter_guide.md
@@ -1,0 +1,338 @@
+# フォーマッタ・Linter使用ガイド
+
+このドキュメントでは、STOCK-INVESTMENT-ANALYZERプロジェクトで使用するコードフォーマッタとLinterの使い方を説明します。
+
+## 目次
+
+1. [導入済みツール](#導入済みツール)
+2. [セットアップ](#セットアップ)
+3. [各ツールの使い方](#各ツールの使い方)
+4. [VSCodeでの自動フォーマット](#vscodeでの自動フォーマット)
+5. [トラブルシューティング](#トラブルシューティング)
+
+---
+
+## 導入済みツール
+
+### コードフォーマッター
+
+- **Black**: Pythonコードの自動フォーマッター
+- **isort**: インポート文の自動ソート
+
+### Linter（静的解析ツール）
+
+- **flake8**: PEP 8準拠チェック、構文エラー検出
+- **pylint**: より詳細な静的解析、コード品質チェック
+
+### 型チェック
+
+- **mypy**: 型ヒントの検証
+
+---
+
+## セットアップ
+
+### 1. 開発用ツールのインストール
+
+仮想環境を有効化してから、以下のコマンドを実行します。
+
+```bash
+# Windowsの場合
+venv\Scripts\activate
+pip install -r requirements-dev.txt
+
+# macOS/Linuxの場合
+source venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+### 2. VSCode拡張機能のインストール
+
+VSCodeで開発する場合、以下の拡張機能をインストールすることを推奨します：
+
+- Python (ms-python.python)
+- Black Formatter (ms-python.black-formatter)
+- isort (ms-python.isort)
+- Flake8 (ms-python.flake8)
+- Pylint (ms-python.pylint)
+- Mypy Type Checker (ms-python.mypy-type-checker)
+- Pylance (ms-python.vscode-pylance)
+
+プロジェクトを開くと、VSCodeが自動的にこれらの拡張機能をインストールするよう推奨します。
+
+---
+
+## 各ツールの使い方
+
+### Black（コードフォーマッター）
+
+#### 基本的な使い方
+
+```bash
+# ファイルをフォーマット（上書き）
+python -m black app/models.py
+
+# ディレクトリ全体をフォーマット
+python -m black app/
+
+# プロジェクト全体をフォーマット
+python -m black .
+
+# チェックのみ（変更しない）
+python -m black --check app/models.py
+
+# 差分を表示
+python -m black --diff app/models.py
+```
+
+#### 設定
+
+設定は[pyproject.toml](../../pyproject.toml)で管理されています。
+
+主な設定：
+- 行の最大長: 79文字
+- 除外ディレクトリ: `migrations/`, `venv/`, `.venv/`, `.git/` など
+
+---
+
+### isort（インポート文ソート）
+
+#### 基本的な使い方
+
+```bash
+# ファイルのインポートをソート（上書き）
+python -m isort app/models.py
+
+# ディレクトリ全体をソート
+python -m isort app/
+
+# プロジェクト全体をソート
+python -m isort .
+
+# チェックのみ（変更しない）
+python -m isort --check-only app/models.py
+
+# 差分を表示
+python -m isort --diff app/models.py
+```
+
+#### 設定
+
+設定は[pyproject.toml](../../pyproject.toml)で管理されています。
+
+インポートの順序：
+1. 標準ライブラリ
+2. サードパーティライブラリ
+3. ローカルモジュール（app, models, services, utils, tests）
+
+---
+
+### flake8（Linter）
+
+#### 基本的な使い方
+
+```bash
+# ファイルをチェック
+python -m flake8 app/models.py
+
+# ディレクトリ全体をチェック
+python -m flake8 app/
+
+# プロジェクト全体をチェック
+python -m flake8 .
+
+# エラー数をカウント
+python -m flake8 app/ --count
+
+# 統計情報を表示
+python -m flake8 app/ --statistics
+```
+
+#### 設定
+
+設定は[.flake8](../../.flake8)ファイルで管理されています。
+
+主な設定：
+- 行の最大長: 79文字
+- 複雑度の閾値: 10
+- 無視するエラー: E203, W503, E501
+
+---
+
+### pylint（静的解析ツール）
+
+#### 基本的な使い方
+
+```bash
+# ファイルをチェック
+python -m pylint app/models.py
+
+# ディレクトリ全体をチェック
+python -m pylint app/
+
+# 特定のメッセージのみ表示
+python -m pylint app/models.py --disable=all --enable=line-too-long
+
+# レポート形式の出力
+python -m pylint app/models.py --output-format=text
+```
+
+#### 設定
+
+設定は[pyproject.toml](../../pyproject.toml)で管理されています。
+
+主な設定：
+- 行の最大長: 79文字
+- 無効化されたメッセージ: C0111, C0103, R0903, W0212
+
+---
+
+### mypy（型チェック）
+
+#### 基本的な使い方
+
+```bash
+# ファイルをチェック
+python -m mypy app/models.py
+
+# ディレクトリ全体をチェック
+python -m mypy app/
+
+# プロジェクト全体をチェック
+python -m mypy .
+
+# エラーコードを表示
+python -m mypy app/models.py --show-error-codes
+```
+
+#### 設定
+
+設定は[pyproject.toml](../../pyproject.toml)で管理されています。
+
+主な設定：
+- Python バージョン: 3.8以上
+- サードパーティライブラリの型スタブがない場合は警告を無視
+
+---
+
+## VSCodeでの自動フォーマット
+
+### 設定内容
+
+[.vscode/settings.json](../../.vscode/settings.json)に以下の設定が記載されています：
+
+- **保存時に自動フォーマット**: 有効
+- **デフォルトフォーマッター**: Black
+- **保存時にインポート文を自動ソート**: 有効
+- **Lintのチェック**: 有効（flake8, pylint）
+
+### 使い方
+
+1. VSCodeでPythonファイルを開く
+2. ファイルを編集
+3. `Ctrl+S`（Windows）または `Cmd+S`（macOS）で保存
+4. 自動的にBlackでフォーマット、isortでインポートがソートされる
+
+### 手動でフォーマット
+
+- **フォーマット**: `Shift+Alt+F`（Windows）または `Shift+Option+F`（macOS）
+- **インポートをソート**: コマンドパレット（`Ctrl+Shift+P`）→ "Organize Imports"
+
+---
+
+## 一括フォーマット・チェックのコマンド
+
+プロジェクト全体を一括でフォーマット・チェックする場合は、以下のコマンドを使用します。
+
+### 一括フォーマット
+
+```bash
+# Blackでフォーマット
+python -m black .
+
+# isortでインポートをソート
+python -m isort .
+```
+
+### 一括チェック
+
+```bash
+# Blackのチェック（変更せずに確認）
+python -m black --check .
+
+# isortのチェック
+python -m isort --check-only .
+
+# flake8のチェック
+python -m flake8 .
+
+# pylintのチェック
+python -m pylint app/ services/ utils/
+
+# mypyのチェック
+python -m mypy .
+```
+
+### すべてのチェックを実行
+
+```bash
+# まとめて実行（Windows）
+python -m black --check . && python -m isort --check-only . && python -m flake8 . && python -m pylint app/ && python -m mypy .
+
+# まとめて実行（macOS/Linux）
+python -m black --check . && \
+python -m isort --check-only . && \
+python -m flake8 . && \
+python -m pylint app/ && \
+python -m mypy .
+```
+
+---
+
+## トラブルシューティング
+
+### 1. ツールがインストールされていない
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+### 2. VSCodeで自動フォーマットが動作しない
+
+- VSCodeの拡張機能がインストールされているか確認
+- コマンドパレット（`Ctrl+Shift+P`）→ "Python: Select Interpreter" で正しいインタープリターが選択されているか確認
+- `.vscode/settings.json`が正しく読み込まれているか確認
+
+### 3. flake8やpylintのエラーが多すぎる
+
+一度にすべてを修正する必要はありません。段階的に修正していきましょう。
+
+優先順位：
+1. **Blackとisortでフォーマット**: `python -m black . && python -m isort .`
+2. **重要なflake8エラーを修正**: 構文エラー、未使用のインポートなど
+3. **pylintの警告を確認**: コード品質の改善
+
+### 4. Blackとflake8の設定が競合している
+
+`.flake8`ファイルで以下のエラーコードを無視しています：
+- `E203`: Blackと競合
+- `W503`: PEP 8で推奨される改行位置
+- `E501`: 行の長さはBlackに任せる
+
+---
+
+## 関連ドキュメント
+
+- [コーディング規約とスタイルガイド](coding_standards.md)
+- [PEP 8 -- Style Guide for Python Code](https://peps.python.org/pep-0008/)
+- [Black公式ドキュメント](https://black.readthedocs.io/)
+- [isort公式ドキュメント](https://pycqa.github.io/isort/)
+- [flake8公式ドキュメント](https://flake8.pycqa.org/)
+- [pylint公式ドキュメント](https://pylint.pycqa.org/)
+- [mypy公式ドキュメント](https://mypy.readthedocs.io/)
+
+---
+
+**更新履歴**
+
+- 2025-10-22: 初版作成 (Issue #108)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,178 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stock-investment-analyzer"
+version = "1.0.0"
+description = "Stock Investment Analyzer - Yahoo Financeから株価データを取得・分析"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "Flask==3.0.0",
+    "SQLAlchemy==2.0.23",
+    "psycopg2-binary==2.9.9",
+    "yfinance==0.2.66",
+    "python-dotenv==1.0.0",
+    "pytest==7.4.3",
+    "selenium==4.15.2",
+    "webdriver-manager==4.0.1",
+    "APScheduler==3.10.4",
+    "pandas>=2.2.0",
+    "flask-socketio==5.3.5",
+    "python-socketio==5.10.0",
+    "waitress==3.0.0",
+    "eventlet==0.36.1",
+    "xlrd>=2.0.1",
+    "openpyxl>=3.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black>=24.0.0",
+    "isort>=5.13.0",
+    "flake8>=7.0.0",
+    "pylint>=3.0.0",
+    "mypy>=1.8.0",
+]
+
+# ===== Black Configuration =====
+[tool.black]
+line-length = 79
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # デフォルトの除外に加えて以下を除外
+  | migrations
+  | venv
+  | \.venv
+  | \.git
+  | \.pytest_cache
+  | __pycache__
+  | build
+  | dist
+  | \.eggs
+)/
+'''
+
+# ===== isort Configuration =====
+[tool.isort]
+profile = "black"
+line_length = 79
+# インポートの順序
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+# 各セクション間に1行の空行を挿入
+lines_after_imports = 2
+# from import の順序
+force_sort_within_sections = true
+# 1行に複数のimportを許可しない
+force_single_line = false
+# importの長さに応じて自動的に折り返し
+multi_line_output = 3
+include_trailing_comma = true
+use_parentheses = true
+ensure_newline_before_comments = true
+# 除外ディレクトリ
+skip_glob = ["venv/*", ".venv/*", "migrations/*", "build/*", "dist/*"]
+# 既知のローカルモジュール
+known_first_party = ["app", "models", "services", "utils", "tests"]
+
+# ===== Flake8 Configuration =====
+# Note: flake8は.flake8ファイルまたはsetup.cfgで設定する必要があります
+# pyproject.tomlをサポートしていないため、.flake8ファイルを別途作成します
+
+# ===== Pylint Configuration =====
+[tool.pylint.main]
+# 並列実行数（0=自動）
+jobs = 0
+# 除外ディレクトリ
+ignore = ["venv", ".venv", "migrations", "build", "dist", ".git"]
+# 除外パターン
+ignore-patterns = ["^\\.#", "test_.*\\.py$"]
+
+[tool.pylint.messages_control]
+# 無効化するメッセージ
+disable = [
+    "C0111",  # missing-docstring（docstringがない場合の警告を無効化）
+    "C0103",  # invalid-name（短い変数名などの警告を無効化）
+    "R0903",  # too-few-public-methods（メソッドが少ないクラスの警告を無効化）
+    "W0212",  # protected-access（protectedメンバーアクセスの警告を無効化）
+]
+
+[tool.pylint.format]
+# 最大行長
+max-line-length = 79
+# インデント
+indent-string = "    "
+# 1行あたりの最大文字数（docstring、コメント用）
+max-module-lines = 1000
+
+[tool.pylint.basic]
+# 良い変数名のパターン
+good-names = ["i", "j", "k", "ex", "Run", "_", "id", "db"]
+# 定数の命名規則
+const-rgx = "[A-Z_][A-Z0-9_]*"
+# クラスの命名規則
+class-rgx = "[A-Z][a-zA-Z0-9]+"
+# 関数の命名規則
+function-rgx = "[a-z_][a-z0-9_]*"
+# メソッドの命名規則
+method-rgx = "[a-z_][a-z0-9_]*"
+# 変数の命名規則
+variable-rgx = "[a-z_][a-z0-9_]*"
+
+[tool.pylint.design]
+# 最大引数数
+max-args = 7
+# 最大ローカル変数数
+max-locals = 20
+# 最大戻り値数
+max-returns = 6
+# 最大分岐数
+max-branches = 15
+# 最大文数
+max-statements = 60
+
+[tool.pylint.imports]
+# 外部依存関係の確認を無効化
+allow-any-import-level = true
+
+# ===== Mypy Configuration =====
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_optional = true
+pretty = true
+show_error_codes = true
+show_column_numbers = true
+show_error_context = true
+
+# 除外ディレクトリ
+exclude = [
+    "venv",
+    ".venv",
+    "migrations",
+    "build",
+    "dist",
+]
+
+# サードパーティライブラリの型スタブがない場合のエラーを無視
+[[tool.mypy.overrides]]
+module = [
+    "yfinance.*",
+    "selenium.*",
+    "webdriver_manager.*",
+    "eventlet.*",
+    "flask_socketio.*",
+]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+black>=24.0.0
+isort>=5.13.0
+flake8>=7.0.0
+flake8-bugbear>=24.0.0
+flake8-docstrings>=1.7.0
+pylint>=3.0.0
+mypy>=1.8.0
+pytest>=7.4.3
+pytest-cov>=4.1.0
+pytest-mock>=3.12.0


### PR DESCRIPTION
## 実装内容

### 導入ツール
- Black (コードフォーマッタ)
- isort (インポート文ソート)
- flake8 (Linter)
- pylint (静的解析ツール)
- mypy (型チェック)

### 設定ファイル
- pyproject.toml: Black, isort, pylint, mypyの統一設定
- .flake8: flake8の設定
- .vscode/settings.json: VSCodeでの自動フォーマット設定
- .vscode/extensions.json: 推奨VSCode拡張機能リスト
- requirements-dev.txt: 開発用依存関係

### ドキュメント
- docs/development/formatter_linter_guide.md: 使用ガイド作成

### その他
- .gitignoreを更新: .vscode配下の設定ファイルを共有可能に

## 設定内容の詳細

### コーディング規約準拠
- PEP 8に準拠（行の最大長: 79文字）
- docs/development/coding_standards.mdに基づいた設定

### VSCode統合
- 保存時に自動フォーマット有効化
- 保存時にインポート文を自動ソート
- flake8, pylintによるリアルタイムチェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)