### PR TITLE
refactor(tests): add pytestmark to docs tests (issue #219)

### DIFF
--- a/tests/docs/test_api_usage_guide.py
+++ b/tests/docs/test_api_usage_guide.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import re
 import unittest
 
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
 
 class TestAPIUsageGuide(unittest.TestCase):
     """API使用例ガイドのテストクラス."""

--- a/tests/docs/test_docs_quality.py
+++ b/tests/docs/test_docs_quality.py
@@ -9,6 +9,9 @@ import re
 import pytest
 
 
+pytestmark = pytest.mark.unit
+
+
 class TestDocsQuality:
     """ドキュメント品質をテストするクラス."""
 

--- a/tests/docs/test_docs_readme_content.py
+++ b/tests/docs/test_docs_readme_content.py
@@ -9,6 +9,9 @@ import re
 import pytest
 
 
+pytestmark = pytest.mark.unit
+
+
 class TestDocsReadmeContent:
     """docs/README.mdの内容と構造をテストするクラス."""
 

--- a/tests/docs/test_docs_structure.py
+++ b/tests/docs/test_docs_structure.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.unit
+
+
 class TestDocsStructure:
     """docsディレクトリの構造をテストするクラス."""
 

--- a/tests/docs/test_readme_links.py
+++ b/tests/docs/test_readme_links.py
@@ -10,6 +10,9 @@ import re
 import pytest
 
 
+pytestmark = pytest.mark.unit
+
+
 class TestReadmeImprovement:
     """README.mdの改善に関するテストクラス."""
 


### PR DESCRIPTION
Add module-level pytest markers to tests under `tests/docs` so they can be selected via `pytest -m unit`.

Files changed:
- tests/docs/test_readme_links.py
- tests/docs/test_docs_structure.py
- tests/docs/test_docs_readme_content.py
- tests/docs/test_docs_quality.py
- tests/docs/test_api_usage_guide.py

This change is part of Issue #219 (test marker refactor).

Closes #219