### PR TITLE
refactor(tests): mark e2e tests with pytestmark=e2e (issue #219)

### DIFF
--- a/tests/e2e/test_api_versioning_e2e.py
+++ b/tests/e2e/test_api_versioning_e2e.py
@@ -10,6 +10,9 @@ import requests
 from app.app import app
 
 
+pytestmark = pytest.mark.e2e
+
+
 class TestAPIVersioningE2E:
     """APIバージョニングのエンドツーエンドテスト."""
 

--- a/tests/e2e/test_e2e_api.py
+++ b/tests/e2e/test_e2e_api.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.e2e
 
 
 class TestAPIE2E:


### PR DESCRIPTION
Normalize pytest markers for E2E tests under `tests/e2e` so they can be selected via `pytest -m e2e`.

Changes:
- tests/e2e/test_api_versioning_e2e.py: add module-level `pytestmark = pytest.mark.e2e`
- tests/e2e/test_e2e_api.py: change marker from `integration` to `e2e`

Closes #219