### PR TITLE
fix(api): re-enable stock_master status tests (Closes #221)

### DIFF
--- a/app/api/stock_master.py
+++ b/app/api/stock_master.py
@@ -9,6 +9,7 @@ import os
 
 from flask import Blueprint, request
 
+from app.models import StockMaster, StockMasterUpdate, get_db_session
 from app.services.jpx.jpx_stock_service import (
     JPXStockService,
     JPXStockServiceError,
@@ -372,8 +373,6 @@ def get_stock_master_status():
         }.
     """
     try:
-        from app.models import StockMaster, StockMasterUpdate, get_db_session
-
         with get_db_session() as session:
             # 銘柄統計を取得
             total_stocks = session.query(StockMaster).count()

--- a/tests/unit/api/test_stock_master_api.py
+++ b/tests/unit/api/test_stock_master_api.py
@@ -331,7 +331,6 @@ class TestStockMasterAPI:
         assert response_data["error"]["code"] == "VALIDATION_ERROR"
         assert "is_activeは" in response_data["message"]
 
-    @pytest.mark.skip(reason="モック設定が複雑なため一時的にスキップ - 主要機能は動作確認済み")
     @patch.dict("os.environ", {"API_KEY": "test_api_key"})
     @patch("app.api.stock_master.get_db_session")
     def test_stock_master_status_with_valid_request_returns_success(
@@ -393,7 +392,6 @@ class TestStockMasterAPI:
         assert response_data["data"]["inactive_stocks"] == 10
         assert response_data["data"]["last_update"]["id"] == 123
 
-    @pytest.mark.skip(reason="モック設定が複雑なため一時的にスキップ - 主要機能は動作確認済み")
     @patch.dict("os.environ", {"API_KEY": "test_api_key"})
     @patch("app.api.stock_master.get_db_session")
     def test_stock_master_status_with_no_update_history_returns_null_last_update(


### PR DESCRIPTION
- Re-enabled two previously skipped tests in `tests/unit/api/test_stock_master_api.py`.
- Imported `get_db_session` and models at module level in `app/api/stock_master.py` so tests can patch `app.api.stock_master.get_db_session`.

Details:
- Removed `@pytest.mark.skip` from the two status tests.
- Fixed indentation and isort/formatting issues (pre-commit hooks applied).

Test results:
- `pytest tests/unit/api/test_stock_master_api.py` -> 13 passed

Closes #221