### PR TITLE
#261: ベースモデルとミックスインの作成

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -46,8 +46,9 @@ per-file-ignores =
     # __init__.pyではF401（未使用のインポート）を許可
     __init__.py:F401,F403
     # テストファイルではdocstringとインポートルールを緩和
-    test_*.py:D100,D101,D102,D103,F401,F811
-    tests/*.py:D100,D101,D102,D103,F401,F811
+    test_*.py:D100,D101,D102,D103,D202,F401,F811
+    tests/*.py:D100,D101,D102,D103,D202,F401,F811
+    tests/**/*.py:D100,D101,D102,D103,D202,F401,F811
     # スクリプトファイルでは複雑度とdocstringチェックを緩和
     scripts/*.py:C901,D100,D103,D202
     fix_*.py:C901,D100,D103

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -41,6 +41,13 @@ from app.models.exceptions import (
 # Master data models
 from app.models.master import StockMaster, StockMasterUpdate
 
+# Mixin classes
+from app.models.mixins import (
+    DictSerializableMixin,
+    SoftDeleteMixin,
+    TimestampMixin,
+)
+
 # Stock data models
 from app.models.stock_data import (
     StockDaily,
@@ -68,6 +75,10 @@ __all__ = [
     # Base classes
     "Base",
     "StockDataBase",
+    # Mixin classes
+    "TimestampMixin",
+    "SoftDeleteMixin",
+    "DictSerializableMixin",
     # Exception classes
     "BaseModelException",
     "DatabaseError",

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,90 +1,68 @@
 """SQLAlchemyのベースクラスと株価データ共通クラス."""
 
-from datetime import datetime
 from decimal import Decimal
-import math
-from typing import Any, Dict, Optional
 
-from sqlalchemy import BigInteger, DateTime, Integer, Numeric, String
+from sqlalchemy import BigInteger, Integer, Numeric, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.sql import func
+
+from app.models.mixins import DictSerializableMixin, TimestampMixin
 
 
 class Base(DeclarativeBase):
-    """全てのモデルクラスの基底クラス."""
+    """全てのモデルクラスの基底クラス.
+
+    SQLAlchemyの宣言的マッピングの基底クラス。
+    全てのORMモデルはこのクラスを継承します。
+
+    Example:
+        >>> class MyModel(Base):
+        ...     __tablename__ = "my_table"
+        ...     id: Mapped[int] = mapped_column(primary_key=True)
+    """
 
     pass
 
 
-class StockDataBase:
+class StockDataBase(TimestampMixin, DictSerializableMixin):
     """株価データの共通カラムと制約を定義するベースクラス.
 
     全ての株価データテーブルで共通して使用されるカラムと
     辞書変換メソッドを提供します。
+
+    Attributes:
+        id: レコードID（主キー、自動採番）
+        symbol: 銘柄コード（例: "7203.T"）
+        open: 始値
+        high: 高値
+        low: 安値
+        close: 終値
+        volume: 出来高
+        created_at: 作成日時（TimestampMixinより）
+        updated_at: 更新日時（TimestampMixinより）
     """
 
     # 共通カラム
     id: Mapped[int] = mapped_column(
-        Integer, primary_key=True, autoincrement=True
+        Integer, primary_key=True, autoincrement=True, comment="レコードID"
     )
-    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
-    open: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
-    high: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
-    low: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
-    close: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
-    volume: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    created_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+    symbol: Mapped[str] = mapped_column(
+        String(20), nullable=False, index=True, comment="銘柄コード"
     )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    open: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, comment="始値"
     )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """モデルインスタンスを辞書形式に変換.
-
-        Returns:
-            Dict[str, Any]: モデルの辞書表現
-        """
-
-        def safe_float_conversion(value):
-            """Decimal値を安全にfloatに変換し、NaN値をNoneに変換する."""
-            if value is None:
-                return None
-            try:
-                float_val = float(value)
-                # NaN値をチェックしてNoneに変換
-                if math.isnan(float_val) or math.isinf(float_val):
-                    return None
-                return float_val
-            except (ValueError, TypeError, OverflowError):
-                return None
-
-        result = {
-            "id": self.id,
-            "symbol": self.symbol,
-            "open": safe_float_conversion(self.open),
-            "high": safe_float_conversion(self.high),
-            "low": safe_float_conversion(self.low),
-            "close": safe_float_conversion(self.close),
-            "volume": self.volume,
-            "created_at": (
-                self.created_at.isoformat() if self.created_at else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat() if self.updated_at else None
-            ),
-        }
-
-        # 日付またはdatetimeフィールドを追加
-        if hasattr(self, "date"):
-            result["date"] = self.date.isoformat() if self.date else None
-        if hasattr(self, "datetime"):
-            result["datetime"] = (
-                self.datetime.isoformat() if self.datetime else None
-            )
-
-        return result
+    high: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, comment="高値"
+    )
+    low: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, comment="安値"
+    )
+    close: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, comment="終値"
+    )
+    volume: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, comment="出来高"
+    )
 
 
 __all__ = [

--- a/app/models/mixins.py
+++ b/app/models/mixins.py
@@ -1,0 +1,124 @@
+"""Mixin classes for database models.
+
+このモジュールは、複数のモデルで共通利用されるMixinクラスを提供します。
+"""
+
+from datetime import datetime
+from decimal import Decimal
+import math
+from typing import Any, Dict, Optional
+
+from sqlalchemy import Boolean, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+
+class TimestampMixin:
+    """タイムスタンプフィールドを提供するMixin.
+
+    全てのモデルで使用する作成日時と更新日時のカラムを提供します。
+
+    Attributes:
+        created_at: レコードの作成日時（タイムゾーン付き）
+        updated_at: レコードの更新日時（タイムゾーン付き、更新時に自動更新）
+    """
+
+    created_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="作成日時",
+    )
+    updated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+        comment="更新日時",
+    )
+
+
+class SoftDeleteMixin:
+    """論理削除機能を提供するMixin.
+
+    物理削除ではなく論理削除を行うためのフラグを提供します。
+
+    Attributes:
+        is_deleted: 削除フラグ（True=削除済み、False=有効）
+        deleted_at: 削除日時（削除時に設定）
+    """
+
+    is_deleted: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+        index=True,
+        comment="削除フラグ（True=削除済み）",
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, comment="削除日時"
+    )
+
+
+class DictSerializableMixin:
+    """辞書型への変換機能を提供するMixin.
+
+    モデルインスタンスをJSON互換の辞書形式に変換するメソッドを提供します。
+
+    Note:
+        このMixinはSQLAlchemyのBaseクラスと組み合わせて使用されます。
+        __table__属性は実行時にSQLAlchemyによって自動的に提供されます。
+    """
+
+    def to_dict(self) -> Dict[str, Any]:
+        """モデルインスタンスを辞書形式に変換.
+
+        Returns:
+            モデルの全カラムを含む辞書
+
+        Note:
+            - Decimal型はfloatに変換されます
+            - NaN/Inf値はNoneに変換されます
+            - datetime型はISO8601形式の文字列に変換されます
+            - date型はYYYY-MM-DD形式の文字列に変換されます
+        """
+
+        def safe_float_conversion(value):
+            """Decimal値を安全にfloatに変換し、NaN値をNoneに変換する."""
+            if value is None:
+                return None
+            try:
+                float_val = float(value)
+                # NaN/Inf値をチェックしてNoneに変換
+                if math.isnan(float_val) or math.isinf(float_val):
+                    return None
+                return float_val
+            except (ValueError, TypeError, OverflowError):
+                return None
+
+        result: Dict[str, Any] = {}
+
+        # 全カラムを走査して辞書に追加
+        for column in self.__table__.columns:  # type: ignore[attr-defined]
+            value = getattr(self, column.name)
+
+            # Decimal型の変換
+            if isinstance(value, Decimal):
+                value = safe_float_conversion(value)
+            # datetime型の変換
+            elif isinstance(value, datetime):
+                value = value.isoformat()
+            # date型の変換
+            elif hasattr(value, "isoformat"):
+                value = value.isoformat()
+
+            result[column.name] = value
+
+        return result
+
+
+__all__ = [
+    "TimestampMixin",
+    "SoftDeleteMixin",
+    "DictSerializableMixin",
+]

--- a/tests/unit/models/test_mixins.py
+++ b/tests/unit/models/test_mixins.py
@@ -1,0 +1,237 @@
+"""Unit tests for mixin classes.
+
+このモジュールは、app/models/mixins.pyで定義されているMixinクラスの
+ユニットテストを提供します。
+"""
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+from app.models.mixins import (
+    DictSerializableMixin,
+    SoftDeleteMixin,
+    TimestampMixin,
+)
+
+
+# テスト用のモデルクラス定義
+class TestTimestampModel(Base, TimestampMixin):
+    """TimestampMixinのテスト用モデル."""
+
+    __tablename__ = "test_timestamp"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+
+
+class TestSoftDeleteModel(Base, SoftDeleteMixin):
+    """SoftDeleteMixinのテスト用モデル."""
+
+    __tablename__ = "test_soft_delete"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+
+
+class TestDictSerializableModel(Base, DictSerializableMixin):
+    """DictSerializableMixinのテスト用モデル."""
+
+    __tablename__ = "test_dict_serializable"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+    price: Mapped[Decimal] = mapped_column()
+
+
+class TestCombinedMixinsModel(
+    Base, TimestampMixin, SoftDeleteMixin, DictSerializableMixin
+):
+    """全てのMixinを組み合わせたテスト用モデル."""
+
+    __tablename__ = "test_combined"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+    value: Mapped[Decimal] = mapped_column()
+
+
+class TestTimestampMixin:
+    """TimestampMixinのテストクラス."""
+
+    def test_timestamp_fields_exist(self):
+        """タイムスタンプフィールドが存在することを確認."""
+        model = TestTimestampModel()
+        assert hasattr(model, "created_at")
+        assert hasattr(model, "updated_at")
+
+    def test_timestamp_fields_are_mapped_columns(self):
+        """タイムスタンプフィールドがMapped型であることを確認."""
+        # MixinのアノテーションはTimestampMixinクラス自体にある
+        assert "created_at" in TimestampMixin.__annotations__
+        assert "updated_at" in TimestampMixin.__annotations__
+
+    def test_timestamp_fields_in_table(self):
+        """タイムスタンプフィールドがテーブルカラムとして定義されていることを確認."""
+        table = TestTimestampModel.__table__
+        assert "created_at" in table.c
+        assert "updated_at" in table.c
+
+
+class TestSoftDeleteMixin:
+    """SoftDeleteMixinのテストクラス."""
+
+    def test_soft_delete_fields_exist(self):
+        """論理削除フィールドが存在することを確認."""
+        model = TestSoftDeleteModel()
+        assert hasattr(model, "is_deleted")
+        assert hasattr(model, "deleted_at")
+
+    def test_is_deleted_default_is_false(self):
+        """is_deletedのデフォルト値がFalseであることを確認."""
+        table = TestSoftDeleteModel.__table__
+        is_deleted_col = table.c.is_deleted
+        assert is_deleted_col.default is not None
+
+    def test_soft_delete_fields_in_table(self):
+        """論理削除フィールドがテーブルカラムとして定義されていることを確認."""
+        table = TestSoftDeleteModel.__table__
+        assert "is_deleted" in table.c
+        assert "deleted_at" in table.c
+
+    def test_deleted_at_is_nullable(self):
+        """deleted_atがnullableであることを確認."""
+        table = TestSoftDeleteModel.__table__
+        deleted_at_col = table.c.deleted_at
+        assert deleted_at_col.nullable is True
+
+
+class TestDictSerializableMixin:
+    """DictSerializableMixinのテストクラス."""
+
+    def test_to_dict_method_exists(self):
+        """to_dict()メソッドが存在することを確認."""
+        model = TestDictSerializableModel()
+        assert hasattr(model, "to_dict")
+        assert callable(model.to_dict)
+
+    def test_to_dict_returns_dict(self):
+        """to_dict()が辞書を返すことを確認."""
+        model = TestDictSerializableModel()
+        model.id = 1
+        model.name = "Test"
+        model.price = Decimal("100.50")
+
+        result = model.to_dict()
+        assert isinstance(result, dict)
+
+    def test_to_dict_includes_all_columns(self):
+        """to_dict()が全てのカラムを含むことを確認."""
+        model = TestDictSerializableModel()
+        model.id = 1
+        model.name = "Test"
+        model.price = Decimal("100.50")
+
+        result = model.to_dict()
+        assert "id" in result
+        assert "name" in result
+        assert "price" in result
+
+    def test_to_dict_converts_decimal_to_float(self):
+        """to_dict()がDecimal型をfloatに変換することを確認."""
+        model = TestDictSerializableModel()
+        model.id = 1
+        model.name = "Test"
+        model.price = Decimal("100.50")
+
+        result = model.to_dict()
+        assert isinstance(result["price"], float)
+        assert result["price"] == 100.50
+
+    def test_to_dict_handles_none_values(self):
+        """to_dict()がNone値を正しく処理することを確認."""
+        model = TestDictSerializableModel()
+        model.id = 1
+        model.name = "Test"
+        model.price = None
+
+        result = model.to_dict()
+        assert result["price"] is None
+
+    def test_to_dict_converts_datetime_to_iso_format(self):
+        """to_dict()がdatetime型をISO8601形式に変換することを確認."""
+        model = TestCombinedMixinsModel()
+        model.id = 1
+        model.name = "Test"
+        model.value = Decimal("100.00")
+        test_time = datetime(2025, 1, 15, 12, 30, 45)
+        model.created_at = test_time
+
+        result = model.to_dict()
+        assert isinstance(result["created_at"], str)
+        assert result["created_at"] == test_time.isoformat()
+
+
+class TestCombinedMixins:
+    """全てのMixinを組み合わせた場合のテストクラス."""
+
+    def test_all_mixin_fields_exist(self):
+        """全てのMixinのフィールドが存在することを確認."""
+        model = TestCombinedMixinsModel()
+
+        # TimestampMixin
+        assert hasattr(model, "created_at")
+        assert hasattr(model, "updated_at")
+
+        # SoftDeleteMixin
+        assert hasattr(model, "is_deleted")
+        assert hasattr(model, "deleted_at")
+
+        # DictSerializableMixin
+        assert hasattr(model, "to_dict")
+
+    def test_to_dict_includes_all_mixin_fields(self):
+        """to_dict()が全てのMixinのフィールドを含むことを確認."""
+        model = TestCombinedMixinsModel()
+        model.id = 1
+        model.name = "Test"
+        model.value = Decimal("100.00")
+        model.is_deleted = False
+
+        result = model.to_dict()
+
+        # 基本フィールド
+        assert "id" in result
+        assert "name" in result
+        assert "value" in result
+
+        # TimestampMixin
+        assert "created_at" in result
+        assert "updated_at" in result
+
+        # SoftDeleteMixin
+        assert "is_deleted" in result
+        assert "deleted_at" in result
+
+    def test_mixin_order_does_not_cause_conflicts(self):
+        """Mixinの順序が競合を引き起こさないことを確認."""
+
+        # 異なる順序でMixinを継承したモデルを作成
+        class AlternateOrderModel(
+            Base, SoftDeleteMixin, TimestampMixin, DictSerializableMixin
+        ):
+            __tablename__ = "test_alternate_order"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        model = AlternateOrderModel()
+        assert hasattr(model, "created_at")
+        assert hasattr(model, "is_deleted")
+        assert hasattr(model, "to_dict")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Issue #261の要件に基づき、ベースモデルとMixinクラスを作成しました。

### 主な変更内容
- `app/models/mixins.py`の新規作成
  - `TimestampMixin`: 作成日時・更新日時フィールドを提供
  - `SoftDeleteMixin`: 論理削除機能を提供
  - `DictSerializableMixin`: モデルの辞書変換機能を提供
- `app/models/base.py`のリファクタリング
  - `StockDataBase`がMixinを継承するよう変更
  - 型ヒントとドキュメントの強化
- `app/models/__init__.py`の更新
  - 新しいMixinクラスをエクスポート
- `tests/unit/models/test_mixins.py`の作成
  - 全Mixin機能の包括的なテスト（16テスト）
- `.flake8`の更新
  - テストファイルでのD202エラーを無視

### 完了条件のチェック
- [x] `app/models/base.py`と`app/models/mixins.py`が作成されている
- [x] `BaseModel`（Base）が共通カラム・型ヒント・ドキュメントを含む
- [x] `TimestampMixin`と`SoftDeleteMixin`が実装されている
- [x] mypyによる型チェックが通る

### Test plan
- [x] 全Mixinのユニットテスト（16テスト）が成功
- [x] mypy型チェックが成功
- [x] flake8リントチェックが成功
- [x] pre-commitフックが全て成功

## 関連Issue
Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)